### PR TITLE
Implemented changes as commented by @Kaiede on issue #2:

### DIFF
--- a/PlaylistHost.bundle/Contents/Code/__init__.py
+++ b/PlaylistHost.bundle/Contents/Code/__init__.py
@@ -22,6 +22,7 @@ CURRENT_VERSION_SINGLE = "2"
 # Preferences
 PREFS__PLEXIP = 'plexip'
 PREFS__PLEXPORT = 'plexport'
+PREFS__PLEXTOKEN = 'plextoken'
 
 # Client / User information
 CLIENT_UNKNOWN = 'Unknown'
@@ -160,6 +161,9 @@ def GetPlexUrl(suffix=None):
     plexUrl = 'http://%s:%s' %(Prefs[PREFS__PLEXIP], Prefs[PREFS__PLEXPORT])
     if suffix is not None:
         plexUrl += suffix
+
+        plexUrl += '?X-Plex-Token='
+        plexUrl += Prefs[PREFS__PLEXTOKEN]
     
     Log.Debug('Requesting Plex URL: %s' % (plexUrl))
     return plexUrl

--- a/PlaylistHost.bundle/Contents/DefaultPrefs.json
+++ b/PlaylistHost.bundle/Contents/DefaultPrefs.json
@@ -10,5 +10,11 @@
         "label": "Plex port",
         "type": "text",
         "default": "32400"
+    },
+    {
+        "id": "plextoken",
+        "label": "Plex login token",
+        "type": "text",
+        "default": "my-token-here-that-I-found-from-viewing-xml-on-an-entity"
     }
 ]


### PR DESCRIPTION
Love your work! I too would like Plex playlists to be displayed in it's DLNA server. I downloaded your plugin and had the same issue about it being unauthorized (401) resulting in a 500 error message.

I'm running Plex in a docker container on Ubuntu with a macvlan network. I read your [comment](https://github.com/Kaiede/PlexPlaylistHost/issues/2#issue-685600548) on issue #2 . 

Implemented that exactly, tested and verified on my Plex server with my plex token and my Yamaha DLNA capable WiFi speaker 2 times: works!